### PR TITLE
Edited linkbridge opening to Aug 2025

### DIFF
--- a/index.md
+++ b/index.md
@@ -35,7 +35,7 @@ sections:
           announcement: Visiting Timbre+ Hillview and outdoor amenities at CMPB from May
             to July 2025? Please walk into CMPB by Hillview Link (via Hillview
             Avenue). The linkbridge to Cashew MRT and link to Rail Corridor will
-            open in July 2025.
+            open in Aug 2025.
           link_text: ""
           link_url: ""
 ---

--- a/pages/Locate Us.md
+++ b/pages/Locate Us.md
@@ -8,7 +8,7 @@ image: /images/CMPB_location_map__caa_7_Feb_2025_.png
 <p><strong>Address<br></strong>91 Hillview Link, Singapore 669723
 <br><a href="https://www.onemap.gov.sg/?lat=1.36762825300103&amp;lng=103.764025830065" rel="noopener nofollow" target="_blank">Get directions here (OneMap)</a>
 </p>
-<h4><strong>The linkbridge to Cashew MRT, and link to Rail Corridor will open in July 2025. Pedestrians may walk into CMPB by Hillview Link (via Hillview Avenue).</strong></h4>
+<h4><strong>The linkbridge to Cashew MRT, and link to Rail Corridor will open in Aug 2025. Pedestrians may walk into CMPB by Hillview Link (via Hillview Avenue).</strong></h4>
 <p></p>
 <div class="isomer-image-wrapper">
 <img style="width: 100%" height="auto" width="100%" alt="" src="/images/CMPB_location_map__caa_11_Feb_2025_.png">


### PR DESCRIPTION
Edited the homepage and "locate us" page. Date changed to Aug 2025 because the TOP of the linkbridge has been postponed to late-Jul 2025.